### PR TITLE
Add novel writing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ SEARCH_API=tavily
   - AI-powered podcast script generation and audio synthesis
   - Automated creation of simple PowerPoint presentations
   - Customizable templates for tailored content
+- 📖 **Fiction Writing Workflow**
+  - Generates a complete novel from an idea or outline
+  - Supports continuing partial drafts and automated revisions
 
 ## Architecture
 

--- a/src/config/agents.py
+++ b/src/config/agents.py
@@ -17,4 +17,8 @@ AGENT_LLM_MAP: dict[str, LLMType] = {
     "ppt_composer": "basic",
     "prose_writer": "basic",
     "prompt_enhancer": "basic",
+    "story_outline_planner": "basic",
+    "story_draft_writer": "basic",
+    "story_critique": "basic",
+    "story_editor": "basic",
 }

--- a/src/prompts/story/story_critique.md
+++ b/src/prompts/story/story_critique.md
@@ -1,0 +1,3 @@
+You are a literary critic.
+Read the draft novel and list the major issues with pacing, coherence, character development, or tone.
+Provide concise bullet points.

--- a/src/prompts/story/story_draft_writer.md
+++ b/src/prompts/story/story_draft_writer.md
@@ -1,0 +1,3 @@
+You are a fiction writer drafting a novel from an outline.
+Write the novel following the outline below.
+If partial draft text is provided, continue the story from that point.

--- a/src/prompts/story/story_editor.md
+++ b/src/prompts/story/story_editor.md
@@ -1,0 +1,3 @@
+You are a professional editor improving a novel draft.
+Revise the story according to the critique notes to fix pacing, coherence and style issues.
+Return the complete revised novel.

--- a/src/prompts/story/story_outline_planner.md
+++ b/src/prompts/story/story_outline_planner.md
@@ -1,0 +1,3 @@
+You are an experienced novelist creating a plot outline.
+Given the user's idea, produce a chapter-by-chapter outline for a full novel.
+Include brief summaries for each chapter.

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -20,6 +20,7 @@ from src.graph.builder import build_graph_with_memory
 from src.podcast.graph.builder import build_graph as build_podcast_graph
 from src.ppt.graph.builder import build_graph as build_ppt_graph
 from src.prose.graph.builder import build_graph as build_prose_graph
+from src.story.graph.builder import build_graph as build_story_graph
 from src.prompt_enhancer.graph.builder import build_graph as build_prompt_enhancer_graph
 from src.rag.builder import build_retriever
 from src.rag.retriever import Resource
@@ -30,6 +31,7 @@ from src.server.chat_request import (
     GeneratePodcastRequest,
     GeneratePPTRequest,
     GenerateProseRequest,
+    GenerateStoryRequest,
     TTSRequest,
 )
 from src.server.mcp_request import MCPServerMetadataRequest, MCPServerMetadataResponse
@@ -299,6 +301,27 @@ async def generate_prose(request: GenerateProseRequest):
         )
     except Exception as e:
         logger.exception(f"Error occurred during prose generation: {str(e)}")
+        raise HTTPException(status_code=500, detail=INTERNAL_SERVER_ERROR_DETAIL)
+
+
+@app.post("/api/story/generate")
+async def generate_story(request: GenerateStoryRequest):
+    try:
+        workflow = build_story_graph()
+        final_state = workflow.invoke(
+            {
+                "input": request.idea,
+                "outline": request.outline or "",
+                "partial_draft": request.partial_draft or "",
+            }
+        )
+        return {
+            "story": final_state["final_draft"],
+            "outline": final_state.get("outline", ""),
+            "critique": final_state.get("critique", ""),
+        }
+    except Exception as e:
+        logger.exception(f"Error occurred during story generation: {str(e)}")
         raise HTTPException(status_code=500, detail=INTERNAL_SERVER_ERROR_DETAIL)
 
 

--- a/src/server/chat_request.py
+++ b/src/server/chat_request.py
@@ -96,6 +96,14 @@ class GenerateProseRequest(BaseModel):
     )
 
 
+class GenerateStoryRequest(BaseModel):
+    idea: str = Field(..., description="The core idea for the story")
+    outline: Optional[str] = Field("", description="Optional story outline")
+    partial_draft: Optional[str] = Field(
+        "", description="Existing partial draft to continue from"
+    )
+
+
 class EnhancePromptRequest(BaseModel):
     prompt: str = Field(..., description="The original prompt to enhance")
     context: Optional[str] = Field(

--- a/src/story/graph/builder.py
+++ b/src/story/graph/builder.py
@@ -1,0 +1,32 @@
+from langgraph.graph import END, START, StateGraph
+
+from .state import StoryState
+from .outline_planner_node import outline_planner_node
+from .draft_writer_node import draft_writer_node
+from .critique_node import critique_node
+from .editor_node import editor_node
+
+
+def start_node(state: StoryState):
+    return "draft_writer" if state.get("outline") else "outline_planner"
+
+
+def build_graph():
+    builder = StateGraph(StoryState)
+    builder.add_node("outline_planner", outline_planner_node)
+    builder.add_node("draft_writer", draft_writer_node)
+    builder.add_node("critique_draft", critique_node)
+    builder.add_node("editor", editor_node)
+    builder.add_conditional_edges(
+        START,
+        start_node,
+        ["outline_planner", "draft_writer"],
+    )
+    builder.add_edge("outline_planner", "draft_writer")
+    builder.add_edge("draft_writer", "critique_draft")
+    builder.add_edge("critique_draft", "editor")
+    builder.add_edge("editor", END)
+    return builder.compile()
+
+
+workflow = build_graph()

--- a/src/story/graph/critique_node.py
+++ b/src/story/graph/critique_node.py
@@ -1,0 +1,20 @@
+import logging
+from langchain.schema import HumanMessage, SystemMessage
+from src.config.agents import AGENT_LLM_MAP
+from src.llms.llm import get_llm_by_type
+from src.prompts.template import get_prompt_template
+from .state import StoryState
+
+logger = logging.getLogger(__name__)
+
+
+def critique_node(state: StoryState):
+    logger.info("Critiquing draft...")
+    model = get_llm_by_type(AGENT_LLM_MAP["story_critique"])
+    response = model.invoke(
+        [
+            SystemMessage(content=get_prompt_template("story/story_critique")),
+            HumanMessage(content=state["first_draft"]),
+        ]
+    )
+    return {"critique": response.content}

--- a/src/story/graph/draft_writer_node.py
+++ b/src/story/graph/draft_writer_node.py
@@ -1,0 +1,23 @@
+import logging
+from langchain.schema import HumanMessage, SystemMessage
+from src.config.agents import AGENT_LLM_MAP
+from src.llms.llm import get_llm_by_type
+from src.prompts.template import get_prompt_template
+from .state import StoryState
+
+logger = logging.getLogger(__name__)
+
+
+def draft_writer_node(state: StoryState):
+    logger.info("Writing story draft...")
+    model = get_llm_by_type(AGENT_LLM_MAP["story_draft_writer"])
+    content = f"Outline:\n{state['outline']}"
+    if state.get("partial_draft"):
+        content += f"\n\nPartial Draft:\n{state['partial_draft']}"
+    response = model.invoke(
+        [
+            SystemMessage(content=get_prompt_template("story/story_draft_writer")),
+            HumanMessage(content=content),
+        ]
+    )
+    return {"first_draft": response.content}

--- a/src/story/graph/editor_node.py
+++ b/src/story/graph/editor_node.py
@@ -1,0 +1,21 @@
+import logging
+from langchain.schema import HumanMessage, SystemMessage
+from src.config.agents import AGENT_LLM_MAP
+from src.llms.llm import get_llm_by_type
+from src.prompts.template import get_prompt_template
+from .state import StoryState
+
+logger = logging.getLogger(__name__)
+
+
+def editor_node(state: StoryState):
+    logger.info("Editing draft...")
+    model = get_llm_by_type(AGENT_LLM_MAP["story_editor"])
+    content = f"Draft:\n{state['first_draft']}\n\nCritique:\n{state['critique']}"
+    response = model.invoke(
+        [
+            SystemMessage(content=get_prompt_template("story/story_editor")),
+            HumanMessage(content=content),
+        ]
+    )
+    return {"final_draft": response.content}

--- a/src/story/graph/outline_planner_node.py
+++ b/src/story/graph/outline_planner_node.py
@@ -1,0 +1,23 @@
+import logging
+from langchain.schema import HumanMessage, SystemMessage
+from src.config.agents import AGENT_LLM_MAP
+from src.llms.llm import get_llm_by_type
+from src.prompts.template import get_prompt_template
+from .state import StoryState
+
+logger = logging.getLogger(__name__)
+
+
+def outline_planner_node(state: StoryState):
+    if state["outline"]:
+        logger.info("Outline provided, skipping generation.")
+        return {}
+    logger.info("Generating story outline...")
+    model = get_llm_by_type(AGENT_LLM_MAP["story_outline_planner"])
+    response = model.invoke(
+        [
+            SystemMessage(content=get_prompt_template("story/story_outline_planner")),
+            HumanMessage(content=state["input"]),
+        ]
+    )
+    return {"outline": response.content}

--- a/src/story/graph/state.py
+++ b/src/story/graph/state.py
@@ -1,0 +1,12 @@
+from langgraph.graph import MessagesState
+
+
+class StoryState(MessagesState):
+    """State for fiction story generation."""
+
+    input: str = ""
+    outline: str = ""
+    partial_draft: str = ""
+    first_draft: str = ""
+    critique: str = ""
+    final_draft: str = ""

--- a/tests/integration/test_story_workflow.py
+++ b/tests/integration/test_story_workflow.py
@@ -1,0 +1,49 @@
+import pytest
+from unittest.mock import MagicMock
+
+from src.story.graph.builder import build_graph
+
+
+def make_llm(response: str):
+    llm = MagicMock()
+    llm.invoke.return_value = MagicMock(content=response)
+    return llm
+
+
+def setup_mocks(monkeypatch):
+    # patch get_llm_by_type in each node module
+    monkeypatch.setattr(
+        "src.story.graph.outline_planner_node.get_llm_by_type",
+        lambda _: make_llm("outline"),
+    )
+    monkeypatch.setattr(
+        "src.story.graph.draft_writer_node.get_llm_by_type",
+        lambda _: make_llm("draft"),
+    )
+    monkeypatch.setattr(
+        "src.story.graph.critique_node.get_llm_by_type",
+        lambda _: make_llm("critique"),
+    )
+    monkeypatch.setattr(
+        "src.story.graph.editor_node.get_llm_by_type",
+        lambda _: make_llm("final"),
+    )
+
+
+@pytest.fixture(autouse=True)
+def patch_llms(monkeypatch):
+    setup_mocks(monkeypatch)
+
+
+def test_workflow_runs_without_outline():
+    workflow = build_graph()
+    state = workflow.invoke({"input": "idea", "outline": "", "partial_draft": ""})
+    assert state["final_draft"] == "final"
+    assert state["outline"] == "outline"
+
+
+def test_workflow_skips_outline_when_provided():
+    workflow = build_graph()
+    state = workflow.invoke({"input": "idea", "outline": "user outline"})
+    assert state["final_draft"] == "final"
+    assert state["outline"] == "user outline"

--- a/web/src/core/api/index.ts
+++ b/web/src/core/api/index.ts
@@ -5,4 +5,5 @@ export * from "./chat";
 export * from "./mcp";
 export * from "./podcast";
 export * from "./prompt-enhancer";
+export * from "./story";
 export * from "./types";

--- a/web/src/core/api/story.ts
+++ b/web/src/core/api/story.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+// SPDX-License-Identifier: MIT
+
+import { resolveServiceURL } from "./resolve-service-url";
+
+export interface GenerateStoryRequest {
+  idea: string;
+  outline?: string;
+  partial_draft?: string;
+}
+
+export interface GenerateStoryResponse {
+  story: string;
+  outline: string;
+  critique: string;
+}
+
+export async function generateStory(
+  req: GenerateStoryRequest,
+): Promise<GenerateStoryResponse> {
+  const response = await fetch(resolveServiceURL("story/generate"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(req),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  return (await response.json()) as GenerateStoryResponse;
+}


### PR DESCRIPTION
## Summary
- support story outline, draft, critique, and edit with new prompts
- register new `story` agents using basic LLM
- expose `/api/story/generate` endpoint returning finished novel
- add frontend helper to call story API
- test story workflow graph

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6847a38276248327af215b00da4b745d